### PR TITLE
Update to 10.2.7 & Fix error when double clicking an already applied group

### DIFF
--- a/LFG Quick Signup.toc
+++ b/LFG Quick Signup.toc
@@ -1,4 +1,4 @@
-## Interface: 100005
+## Interface: 100207
 ## Title: LFG Quick Signup
 
 core.lua

--- a/core.lua
+++ b/core.lua
@@ -1,5 +1,7 @@
 -- Declare function to automatically apply to a group
 local function SignUp(button)
+	-- If an application is already open, do not continue
+	if (button.isApplication) then return end
 	-- Click the "SignUp" Button on the LFG frame
 	LFGListSearchPanel_SignUp(button:GetParent():GetParent():GetParent())
 	-- Click the "SignUp" Button on the Role Select dialog


### PR DESCRIPTION
Update to 10.2.7 & Fix error when double clicking an already applied group